### PR TITLE
IH_87-implement-new-varients-of-items-for-underground

### DIFF
--- a/Entities/Blocks/BlockStates/BrickBlockUndergroundNormalState.cs
+++ b/Entities/Blocks/BlockStates/BrickBlockUndergroundNormalState.cs
@@ -1,0 +1,12 @@
+﻿using Mario.Entities.Abstract;
+
+namespace Mario.Entities.Blocks.BlockStates
+{
+    public class BrickBlockUndergroundNormalState : AbstractEntityState
+    {
+        public BrickBlockUndergroundNormalState() : base()
+        {
+            sprite = spriteFactory.CreateSprite("brickTileUnderground");
+        }
+    }
+}

--- a/Entities/Blocks/BlockStates/FloorBlockUndergroundState.cs
+++ b/Entities/Blocks/BlockStates/FloorBlockUndergroundState.cs
@@ -1,0 +1,12 @@
+﻿using Mario.Entities.Abstract;
+
+namespace Mario.Entities.Blocks.BlockStates
+{
+    public class FloorBlockUndergroundState : AbstractEntityState
+    {
+        public FloorBlockUndergroundState() : base()
+        {
+            sprite = spriteFactory.CreateSprite("floorTileUnderground");
+        }
+    }
+}

--- a/Entities/Blocks/BrickBlock.cs
+++ b/Entities/Blocks/BrickBlock.cs
@@ -6,13 +6,20 @@ namespace Mario.Entities.Blocks
 {
     public class BrickBlock : AbstractBlock
     {
-        public BrickBlock(Vector2 position, bool breakable, bool collidable, string item)
+        public BrickBlock(Vector2 position, bool breakable, bool collidable, bool isUnderground = false)
         {
             this.position = position;
-            currentState = new BrickBlockNormalState();
             isCollidable = collidable;
             isBreakable = breakable;
             canBeCombined = false;
+
+            if (isUnderground)
+            {
+                currentState = new BrickBlockUndergroundNormalState();
+            } else
+            {
+                currentState = new BrickBlockNormalState();
+            }
         }
 
         // Block will be broken

--- a/Entities/Blocks/FloorBlock.cs
+++ b/Entities/Blocks/FloorBlock.cs
@@ -6,13 +6,21 @@ namespace Mario.Entities.Blocks
 {
     public class FloorBlock : AbstractBlock
     {
-        public FloorBlock(Vector2 position, bool breakable, bool collidable)
+        public FloorBlock(Vector2 position, bool breakable, bool collidable, bool isUnderground = false)
         {
             this.position = position;
-            currentState = new FloorBlockState();
             isCollidable = collidable;
             isBreakable = breakable;
             canBeCombined = true;
+
+            if (isUnderground)
+            {
+                currentState = new FloorBlockUndergroundState();
+            }
+            else
+            {
+                currentState = new FloorBlockState();
+            }
         }
 
         public override void GetHit()

--- a/Entities/Blocks/MysteryBlock.cs
+++ b/Entities/Blocks/MysteryBlock.cs
@@ -32,6 +32,9 @@ namespace Mario.Entities.Blocks
                 case "coin":
                     item = ObjectFactory.Instance.CreateItem("coin", position);
                     break;
+                case "coinUnderground":
+                    item = ObjectFactory.Instance.CreateItem("coinUnderground", position);
+                    break;
                 case "1up":
                     item = ObjectFactory.Instance.CreateItem("1up", position);
                     break;

--- a/Entities/Items/Coin.cs
+++ b/Entities/Items/Coin.cs
@@ -5,10 +5,15 @@ namespace Mario.Entities.Items
 {
     public class Coin : AbstractItem
     {
-        public Coin(Vector2 position)
+        public Coin(Vector2 position, bool isUnderground = false)
         {
             this.position = position;
-            currentState = new CoinState();
+            if (isUnderground) {
+                currentState = new UndergroundCoinState();
+            } else
+            {
+                currentState = new CoinState();
+            }
         }
 
         public override void MakeVisible()

--- a/Entities/Items/ItemStates/UndergroundCoinState.cs
+++ b/Entities/Items/ItemStates/UndergroundCoinState.cs
@@ -1,0 +1,11 @@
+﻿using Mario.Entities.Abstract;
+
+namespace Mario.Entities.Items.ItemStates;
+
+public class UndergroundCoinState : AbstractEntityState
+{
+    public UndergroundCoinState() : base()
+    {
+        sprite = spriteFactory.CreateSprite("coinUnderground");
+    }
+}

--- a/Global/SpriteVariables.cs
+++ b/Global/SpriteVariables.cs
@@ -20,8 +20,8 @@ public class SpriteVariables
             { "1up", new int[] { 0, 64, 16, 16, 1, 1, 0 } },
             //underground
             { "coinUnderground", new int[] { 0, 48, 16, 16, 4, 1, 0 } },
-            { "brickTileUnderground", new int[] { 0, 16, 16, 16, 1, 1, 1 } },
-            { "floorTileUnderground", new int[] { 32, 16, 16, 16, 1, 1, 1 } },
+            { "brickTileUnderground", new int[] { 64, 16, 16, 16, 1, 1, 1 } },
+            { "floorTileUnderground", new int[] { 48, 16, 16, 16, 1, 1, 1 } },
             { "pipeTileSideways", new int[] { 48, 32, 64, 32, 1, 1, 1 } },
             // blocks
             { "questionMarkTile", new int[] { 0, 0, 16, 16, 3, 1, 1 } },

--- a/Levels/Sprint3.json
+++ b/Levels/Sprint3.json
@@ -31,7 +31,7 @@
   ],
   "blockSections": [
     {
-      "type": "floor",
+      "type": "floorUnderground",
       "startingX": 0,
       "startingY": 14,
       "endingX": 60,
@@ -41,7 +41,7 @@
       "item": "none"
     },
     {
-      "type": "floor",
+      "type": "floorUnderground",
       "startingX": 0,
       "startingY": 13,
       "endingX": 60,
@@ -93,12 +93,11 @@
       "item": "1up"
     },
     {
-      "type": "mystery",
+      "type": "brickUnderground",
       "x": 10,
       "y": 9,
       "collidable": true,
-      "breakable": false,
-      "item": "fireflower"
+      "breakable": true
     },
     {
       "type": "mystery",
@@ -122,7 +121,7 @@
       "y": 9,
       "collidable": true,
       "breakable": true,
-      "item": "coin"
+      "item": "coinUnderground"
     },
     {
       "type": "mystery",
@@ -130,7 +129,7 @@
       "y": 9,
       "collidable": true,
       "breakable": true,
-      "item": "coin"
+      "item": "coinUnderground"
     },
     {
       "type": "mystery",

--- a/Singletons/ObjectFactory.cs
+++ b/Singletons/ObjectFactory.cs
@@ -35,14 +35,16 @@ namespace Mario.Singletons
 
         public IBlock CreateBlock(string type, Vector2 position, bool breakeable, bool collideable, string item)
         {
-            type = type.ToLower();
-            item = item.ToLower();
             switch (type)
             {
                 case "floor":
                     return new FloorBlock(position, breakeable, collideable);
+                case "floorUnderground":
+                    return new FloorBlock(position, breakeable, collideable, true);
                 case "brick":
-                    return new BrickBlock(position, breakeable, collideable, item);
+                    return new BrickBlock(position, breakeable, collideable);
+                case "brickUnderground":
+                    return new BrickBlock(position, breakeable, collideable, true);
                 case "mystery":
                     return new MysteryBlock(position, breakeable, collideable, item);
                 default:
@@ -52,13 +54,14 @@ namespace Mario.Singletons
 
         public IItem CreateItem(string type, Vector2 position)
         {
-            type = type.ToLower();
             switch (type)
             {
                 case "none":
                     return null;
                 case "coin":
                     return new Coin(position);
+                case "coinUnderground":
+                    return new Coin(position, true);
                 case "fireflower":
                     return new FireFlower(position);
                 case "star":


### PR DESCRIPTION
﻿
# Description

New feat: Added underground variants for coins, brick blocks, and floor blocks. 
Bug Fix: Updated sprite variables to allow the correct sprites to be displayed. 
Change: Updated the object factory slightly to allow for construction of these objects. 

closes #87 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# How To Test

There are underground versions for brick blocks, floor blocks, and coins in the JSON file. Run the game to make sure they behave as the same as their counterparts. Feel free to change the JSON file to test more if necessary. 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

